### PR TITLE
leverage tailwindcss

### DIFF
--- a/frontend/src/app/(tabs)/explore.tsx
+++ b/frontend/src/app/(tabs)/explore.tsx
@@ -1,5 +1,5 @@
 import Ionicons from "@expo/vector-icons/Ionicons";
-import { StyleSheet, Image, Platform } from "react-native";
+import { Image, Platform } from "react-native";
 
 import { Collapsible } from "@/src/components/Collapsible";
 import { ExternalLink } from "@/src/components/ExternalLink";
@@ -12,10 +12,14 @@ export default function TabTwoScreen() {
     <ParallaxScrollView
       headerBackgroundColor={{ light: "#D0D0D0", dark: "#353636" }}
       headerImage={
-        <Ionicons size={310} name="code-slash" style={styles.headerImage} />
+        <Ionicons
+          size={310}
+          name="code-slash"
+          className="text-gray-500 absolute bottom-[-90px] left-[-35px]"
+        />
       }
     >
-      <ThemedView style={styles.titleContainer}>
+      <ThemedView className="flex-row gap-2">
         <ThemedText type="title">Explore</ThemedText>
       </ThemedView>
       <ThemedText>
@@ -53,7 +57,7 @@ export default function TabTwoScreen() {
         </ThemedText>
         <Image
           source={require("@/assets/images/react-logo.png")}
-          style={{ alignSelf: "center" }}
+          className="self-center"
         />
         <ExternalLink href="https://reactnative.dev/docs/images">
           <ThemedText type="link">Learn more</ThemedText>
@@ -63,9 +67,7 @@ export default function TabTwoScreen() {
         <ThemedText>
           Open <ThemedText type="defaultSemiBold">app/_layout.tsx</ThemedText>{" "}
           to see how to load{" "}
-          <ThemedText style={{ fontFamily: "SpaceMono" }}>
-            custom fonts such as this one.
-          </ThemedText>
+          <ThemedText>custom fonts such as this one.</ThemedText>
         </ThemedText>
         <ExternalLink href="https://docs.expo.dev/versions/latest/sdk/font">
           <ThemedText type="link">Learn more</ThemedText>
@@ -109,16 +111,3 @@ export default function TabTwoScreen() {
     </ParallaxScrollView>
   );
 }
-
-const styles = StyleSheet.create({
-  headerImage: {
-    color: "#808080",
-    bottom: -90,
-    left: -35,
-    position: "absolute",
-  },
-  titleContainer: {
-    flexDirection: "row",
-    gap: 8,
-  },
-});

--- a/frontend/src/app/(tabs)/index.tsx
+++ b/frontend/src/app/(tabs)/index.tsx
@@ -1,5 +1,4 @@
-import { Image, StyleSheet, Platform } from "react-native";
-
+import { Image, Platform } from "react-native";
 import { HelloWave } from "@/src/components/HelloWave";
 import ParallaxScrollView from "@/src/components/ParallaxScrollView";
 import { ThemedText } from "@/src/components/ThemedText";
@@ -12,15 +11,15 @@ export default function HomeScreen() {
       headerImage={
         <Image
           source={require("@/assets/images/partial-react-logo.png")}
-          style={styles.reactLogo}
+          className="absolute bottom-0 left-0 h-44 w-72"
         />
       }
     >
-      <ThemedView style={styles.titleContainer}>
+      <ThemedView className="flex-row items-center gap-2">
         <ThemedText type="title">Welcome!</ThemedText>
         <HelloWave />
       </ThemedView>
-      <ThemedView style={styles.stepContainer}>
+      <ThemedView className="gap-2 mb-2">
         <ThemedText type="subtitle">Step 1: Try it</ThemedText>
         <ThemedText>
           Edit{" "}
@@ -32,14 +31,14 @@ export default function HomeScreen() {
           to open developer tools.
         </ThemedText>
       </ThemedView>
-      <ThemedView style={styles.stepContainer}>
+      <ThemedView className="gap-2 mb-2">
         <ThemedText type="subtitle">Step 2: Explore</ThemedText>
         <ThemedText>
           Tap the Explore tab to learn more about what's included in this
           starter app.
         </ThemedText>
       </ThemedView>
-      <ThemedView style={styles.stepContainer}>
+      <ThemedView className="gap-2 mb-2">
         <ThemedText type="subtitle">Step 3: Get a fresh start</ThemedText>
         <ThemedText>
           When you're ready, run{" "}
@@ -53,22 +52,3 @@ export default function HomeScreen() {
     </ParallaxScrollView>
   );
 }
-
-const styles = StyleSheet.create({
-  titleContainer: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 8,
-  },
-  stepContainer: {
-    gap: 8,
-    marginBottom: 8,
-  },
-  reactLogo: {
-    height: 178,
-    width: 290,
-    bottom: 0,
-    left: 0,
-    position: "absolute",
-  },
-});

--- a/frontend/src/app/+not-found.tsx
+++ b/frontend/src/app/+not-found.tsx
@@ -7,7 +7,7 @@ export default function NotFoundScreen() {
   return (
     <>
       <Stack.Screen options={{ title: "Oops!" }} />
-      <ThemedView className="flex-1 items-center justify-center p-5">
+      <ThemedView className="flex-1 items-center justify-center p-6">
         <ThemedText type="title">This screen doesn't exist.</ThemedText>
         <Link href="/" className="mt-4 py-4">
           <ThemedText type="link">Go to home screen!</ThemedText>

--- a/frontend/src/app/+not-found.tsx
+++ b/frontend/src/app/+not-found.tsx
@@ -1,5 +1,4 @@
 import { Link, Stack } from "expo-router";
-import { StyleSheet } from "react-native";
 
 import { ThemedText } from "@/src/components/ThemedText";
 import { ThemedView } from "@/src/components/ThemedView";
@@ -8,25 +7,12 @@ export default function NotFoundScreen() {
   return (
     <>
       <Stack.Screen options={{ title: "Oops!" }} />
-      <ThemedView style={styles.container}>
+      <ThemedView className="flex-1 items-center justify-center p-5">
         <ThemedText type="title">This screen doesn't exist.</ThemedText>
-        <Link href="/" style={styles.link}>
+        <Link href="/" className="mt-4 py-4">
           <ThemedText type="link">Go to home screen!</ThemedText>
         </Link>
       </ThemedView>
     </>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
-    padding: 20,
-  },
-  link: {
-    marginTop: 15,
-    paddingVertical: 15,
-  },
-});

--- a/frontend/src/components/Collapsible.tsx
+++ b/frontend/src/components/Collapsible.tsx
@@ -16,7 +16,7 @@ export function Collapsible({
   return (
     <ThemedView>
       <TouchableOpacity
-        className="flex-row items-center gap-1.5"
+        className="flex-row items-center gap-2"
         onPress={() => setIsOpen((value) => !value)}
         activeOpacity={0.8}
       >

--- a/frontend/src/components/Collapsible.tsx
+++ b/frontend/src/components/Collapsible.tsx
@@ -1,6 +1,6 @@
 import Ionicons from "@expo/vector-icons/Ionicons";
 import { PropsWithChildren, useState } from "react";
-import { StyleSheet, TouchableOpacity, useColorScheme } from "react-native";
+import { TouchableOpacity, useColorScheme } from "react-native";
 
 import { ThemedText } from "@/src/components/ThemedText";
 import { ThemedView } from "@/src/components/ThemedView";
@@ -16,7 +16,7 @@ export function Collapsible({
   return (
     <ThemedView>
       <TouchableOpacity
-        style={styles.heading}
+        className="flex-row items-center gap-1.5"
         onPress={() => setIsOpen((value) => !value)}
         activeOpacity={0.8}
       >
@@ -27,19 +27,7 @@ export function Collapsible({
         />
         <ThemedText type="defaultSemiBold">{title}</ThemedText>
       </TouchableOpacity>
-      {isOpen && <ThemedView style={styles.content}>{children}</ThemedView>}
+      {isOpen && <ThemedView className="mt-1.5 ml-6">{children}</ThemedView>}
     </ThemedView>
   );
 }
-
-const styles = StyleSheet.create({
-  heading: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 6,
-  },
-  content: {
-    marginTop: 6,
-    marginLeft: 24,
-  },
-});

--- a/frontend/src/components/ExternalLink.tsx
+++ b/frontend/src/components/ExternalLink.tsx
@@ -1,18 +1,18 @@
-import { Link } from 'expo-router';
-import { openBrowserAsync } from 'expo-web-browser';
-import { type ComponentProps } from 'react';
-import { Platform } from 'react-native';
+import { Link } from "expo-router";
+import { openBrowserAsync } from "expo-web-browser";
+import { type ComponentProps } from "react";
+import { Platform } from "react-native";
 
-type Props = Omit<ComponentProps<typeof Link>, 'href'> & { href: string };
+type Props = Omit<ComponentProps<typeof Link>, "href"> & { href: string };
 
 export function ExternalLink({ href, ...rest }: Props) {
   return (
     <Link
       target="_blank"
       {...rest}
-      href={href}
+      href={href as any}
       onPress={async (event) => {
-        if (Platform.OS !== 'web') {
+        if (Platform.OS !== "web") {
           // Prevent the default behavior of linking to the default browser on native.
           event.preventDefault();
           // Open the link in an in-app browser.

--- a/frontend/src/components/HelloWave.tsx
+++ b/frontend/src/components/HelloWave.tsx
@@ -1,4 +1,3 @@
-import { StyleSheet } from "react-native";
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -6,8 +5,7 @@ import Animated, {
   withRepeat,
   withSequence,
 } from "react-native-reanimated";
-
-import { ThemedText } from "@/src/components/ThemedText";
+import { Text } from "react-native";
 
 export function HelloWave() {
   const rotationAnimation = useSharedValue(0);
@@ -25,16 +23,11 @@ export function HelloWave() {
   }));
 
   return (
-    <Animated.View style={animatedStyle}>
-      <ThemedText style={styles.text}>👋</ThemedText>
+    <Animated.View
+      style={animatedStyle}
+      className="transform translate-y-2 opacity-50"
+    >
+      <Text className="text-lg font-bold">👋</Text>
     </Animated.View>
   );
 }
-
-const styles = StyleSheet.create({
-  text: {
-    fontSize: 28,
-    lineHeight: 32,
-    marginTop: -6,
-  },
-});

--- a/frontend/src/components/ParallaxScrollView.tsx
+++ b/frontend/src/components/ParallaxScrollView.tsx
@@ -1,12 +1,11 @@
 import type { PropsWithChildren, ReactElement } from "react";
-import { StyleSheet, useColorScheme } from "react-native";
+import { useColorScheme } from "react-native";
 import Animated, {
   interpolate,
   useAnimatedRef,
   useAnimatedStyle,
   useScrollViewOffset,
 } from "react-native-reanimated";
-
 import { ThemedView } from "@/src/components/ThemedView";
 
 const HEADER_HEIGHT = 250;
@@ -47,35 +46,21 @@ export default function ParallaxScrollView({
   });
 
   return (
-    <ThemedView style={styles.container}>
+    <ThemedView className="flex-1">
       <Animated.ScrollView ref={scrollRef} scrollEventThrottle={16}>
         <Animated.View
           style={[
-            styles.header,
             { backgroundColor: headerBackgroundColor[colorScheme] },
             headerAnimatedStyle,
           ]}
+          className="h-64 overflow-hidden"
         >
           {headerImage}
         </Animated.View>
-        <ThemedView style={styles.content}>{children}</ThemedView>
+        <ThemedView className="flex-1 p-8 gap-4 overflow-hidden">
+          {children}
+        </ThemedView>
       </Animated.ScrollView>
     </ThemedView>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  header: {
-    height: 250,
-    overflow: "hidden",
-  },
-  content: {
-    flex: 1,
-    padding: 32,
-    gap: 16,
-    overflow: "hidden",
-  },
-});

--- a/frontend/src/components/ThemedText.tsx
+++ b/frontend/src/components/ThemedText.tsx
@@ -1,11 +1,13 @@
-import { Text, type TextProps, StyleSheet } from "react-native";
-
+import React from "react";
+import { Text } from "react-native";
 import { useThemeColor } from "@/src/hooks/useThemeColor";
 
-export type ThemedTextProps = TextProps & {
+type ThemedTextProps = {
+  style?: object;
   lightColor?: string;
   darkColor?: string;
   type?: "default" | "title" | "defaultSemiBold" | "subtitle" | "link";
+  children?: React.ReactNode;
 };
 
 export function ThemedText({
@@ -13,48 +15,22 @@ export function ThemedText({
   lightColor,
   darkColor,
   type = "default",
+  children,
   ...rest
 }: ThemedTextProps) {
   const color = useThemeColor({ light: lightColor, dark: darkColor }, "text");
 
+  const variantClasses = {
+    default: "text-base leading-6",
+    defaultSemiBold: "text-base leading-6 font-semibold",
+    title: "text-4xl font-bold leading-10",
+    subtitle: "text-xl font-bold",
+    link: "leading-7 text-base text-blue-600",
+  };
+
   return (
-    <Text
-      style={[
-        { color },
-        type === "default" ? styles.default : undefined,
-        type === "title" ? styles.title : undefined,
-        type === "defaultSemiBold" ? styles.defaultSemiBold : undefined,
-        type === "subtitle" ? styles.subtitle : undefined,
-        type === "link" ? styles.link : undefined,
-        style,
-      ]}
-      {...rest}
-    />
+    <Text style={[{ color }, style]} className={variantClasses[type]} {...rest}>
+      {children}
+    </Text>
   );
 }
-
-const styles = StyleSheet.create({
-  default: {
-    fontSize: 16,
-    lineHeight: 24,
-  },
-  defaultSemiBold: {
-    fontSize: 16,
-    lineHeight: 24,
-    fontWeight: "600",
-  },
-  title: {
-    fontSize: 32,
-    fontWeight: "bold",
-    lineHeight: 32,
-  },
-  subtitle: {
-    fontSize: 20,
-    fontWeight: "bold",
-  },
-  link: {
-    lineHeight: 30,
-    fontSize: 16,
-    color: "#0a7ea4",
-  },
-});

--- a/frontend/src/components/navigation/TabBarIcon.tsx
+++ b/frontend/src/components/navigation/TabBarIcon.tsx
@@ -1,9 +1,12 @@
 // You can explore the built-in icon families and icons on the web at https://icons.expo.fyi/
 
-import Ionicons from '@expo/vector-icons/Ionicons';
-import { type IconProps } from '@expo/vector-icons/build/createIconSet';
-import { type ComponentProps } from 'react';
+import Ionicons from "@expo/vector-icons/Ionicons";
+import { type IconProps } from "@expo/vector-icons/build/createIconSet";
+import { type ComponentProps } from "react";
 
-export function TabBarIcon({ style, ...rest }: IconProps<ComponentProps<typeof Ionicons>['name']>) {
-  return <Ionicons size={28} style={[{ marginBottom: -3 }, style]} {...rest} />;
+export function TabBarIcon({
+  style,
+  ...rest
+}: IconProps<ComponentProps<typeof Ionicons>["name"]>) {
+  return <Ionicons size={28} className="mb-[-3px]" style={style} {...rest} />;
 }


### PR DESCRIPTION
Since we have integrated [NativeWind](https://www.nativewind.dev/overview/) into our Expo app, it makes sense to remove all the existing StyleSheet usage and adopt [Tailwind CSS](https://tailwindcss.com/) for styling moving forward.

This PR replaces all the StyleSheet instances used during the setup stage with Tailwind CSS.
(Note: Some styles may not exactly match the original ones, but that’s not an issue in this case since most of these files will be removed later as we create our own pages. The goal is to make the codebase more consistent in terms of styling methods.)