### PR TITLE
Update video embedding

### DIFF
--- a/frontend/src/app/(tabs)/(home)/details/[category]/[topicId]/[position]/index.tsx
+++ b/frontend/src/app/(tabs)/(home)/details/[category]/[topicId]/[position]/index.tsx
@@ -185,7 +185,10 @@ export default function Videos() {
           style={{ marginTop: Platform.OS === "ios" ? 20 : 0 }}
           javaScriptEnabled={true}
           domStorageEnabled={true}
-          source={{ uri: `https://www.youtube.com/embed/${videoData.link}` }}
+          source={{ 
+            uri: `https://www.youtube-nocookie.com/embed/${videoData.link}`,
+          }}
+          referrerpolicy="strict-origin-when-cross-origin"
         />
       </SafeAreaView>
       <View className="flex-row justify-between w-full px-10 mt-4">


### PR DESCRIPTION
Changed link from "https://www.youtube.com/embed/${videoData.link}" to "https://www.youtube-nocookie.com/embed/${videoData.link}" & added `referrerpolicy="strict-origin-when-cross-origin"` attribute to accomodate YouTube video embedding changes 